### PR TITLE
Only run local test action on commits on branches

### DIFF
--- a/.github/workflows/local-tests.yml
+++ b/.github/workflows/local-tests.yml
@@ -1,6 +1,9 @@
 name: Local Tests
 
-on: [push]
+on:
+  push:
+    branches:
+      - '**'
 
 jobs:
   build:


### PR DESCRIPTION
## Proposed Changes

Currently there are 2 identical Local Test runs for commits that also set a tag (e.g. `v0.0.5`). This should change it so that tags are ignored. 

## Type of Changes

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update

## Breaking Changes

In general avoid breaking changes, but if you think it is necessary give your reasoning in the _Further Comments_ section.

- [x] I have not introduced breaking changes

## Further Comments

I also considered limiting the testing to only PRs. But as the tests are still fast, I do not see any harm in building all commits for now.
