### PR TITLE
Analytics status should always be reflected in file

### DIFF
--- a/src/utils/usage-analytics.ts
+++ b/src/utils/usage-analytics.ts
@@ -7,12 +7,15 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 export async function usageAnalytics(projectDir: string, agreeToAnalytics: boolean, salt?: string) {
+  const analyticsFilePath = path.resolve(projectDir, 'sap-cloud-sdk-analytics.json');
   if (agreeToAnalytics === false) {
-    return;
+    return fs.writeFileSync(analyticsFilePath, JSON.stringify({ enabled: false }));
   }
 
   if (agreeToAnalytics || (await cli.confirm('Do you want to provide anonymous usage analytics to help us improve the SDK? (y|n)'))) {
     const jsonContent = salt ? { enabled: true, salt } : { enabled: true };
-    fs.writeFileSync(path.resolve(projectDir, 'sap-cloud-sdk-analytics.json'), JSON.stringify(jsonContent));
+    fs.writeFileSync(analyticsFilePath, JSON.stringify(jsonContent));
+  } else {
+    fs.writeFileSync(analyticsFilePath, JSON.stringify({ enabled: false }));
   }
 }

--- a/test/init.spec.ts
+++ b/test/init.spec.ts
@@ -163,4 +163,13 @@ describe('Init', () => {
 
     expect(JSON.parse(fs.readFileSync(`${projectDir}/sap-cloud-sdk-analytics.json`, 'utf8'))).toEqual({ enabled: true, salt: 'SAPCLOUDSDK4LIFE' });
   }, 60000);
+
+  it('should add a disabled analytics file', async () => {
+    const projectDir = getCleanProjectDir('add-to-gitignore');
+    fs.copySync(expressAppDir, projectDir, { recursive: true });
+
+    await Init.run(['--projectName=testingApp', '--startCommand="npm start"', `--projectDir=${projectDir}`, '--no-analytics']);
+
+    expect(JSON.parse(fs.readFileSync(`${projectDir}/sap-cloud-sdk-analytics.json`, 'utf8'))).toEqual({ enabled: false });
+  }, 60000);
 });


### PR DESCRIPTION
## Proposed Changes

If the user declines to provide usage data, write the analytics file with `{ enabled: false }`.

## Type of Changes

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation Update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

## Breaking Changes

In general avoid breaking changes, but if you think it is necessary give your reasoning in the _Further Comments_ section.

- [x] I have not introduced breaking changes

## Further Comments

If the changes are complex, please discuss what alternatives you have evaluated and why you picked this particular solution. Please make sure to highlight any trade-offs that we should know about.
