### PR TITLE
Ignore artifacts of previously cancelled test runs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,13 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  modulePathIgnorePatterns: ['<rootDir>/lib', '<rootDir>/bin', '<rootDir>/tmp', '<rootDir>/test/nest', '<rootDir>/test/express'],
-  roots: ["test"]
+  modulePathIgnorePatterns: [
+    '<rootDir>/lib',
+    '<rootDir>/bin',
+    '<rootDir>/tmp',
+    '<rootDir>/test/nest',
+    '<rootDir>/test/express',
+    '<rootDir>/test/[^/]*/[^/]*-spec'
+  ],
+  roots: ['test']
 };

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "repository": "https://github.com/SAP/cloud-sdk-cli",
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
-    "pretest": "tslint -p . -t stylish && tslint -p test -t stylish && prettier -c \"**/*.ts\"",
+    "pretest": "rimraf test/**/*-spec/ && tslint -p . -t stylish && tslint -p test -t stylish && prettier -c \"**/*.ts\"",
     "prettier": "prettier --write \"**/*.ts\"",
     "prepack": "rm -rf lib && tsc -b && cp -R src/templates lib/ && oclif-dev manifest && oclif-dev readme",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "repository": "https://github.com/SAP/cloud-sdk-cli",
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
-    "pretest": "rimraf test/**/*-spec/ && tslint -p . -t stylish && tslint -p test -t stylish && prettier -c \"**/*.ts\"",
+    "pretest": "tslint -p . -t stylish && tslint -p test -t stylish && prettier -c \"**/*.ts\"",
     "prettier": "prettier --write \"**/*.ts\"",
     "prepack": "rm -rf lib && tsc -b && cp -R src/templates lib/ && oclif-dev manifest && oclif-dev readme",
     "test": "jest",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -68,6 +68,10 @@ export default class Init extends Command {
     analyticsSalt: flags.string({
       hidden: true,
       description: 'Set salt for analytics. This should only be used for CI builds.'
+    }),
+    skipInstall: flags.boolean({
+      hidden: true,
+      description: 'Skip installing npm dependencies. If you use this, make sure to install manually afterwards.'
     })
   };
 
@@ -121,7 +125,8 @@ export default class Init extends Command {
         },
         {
           title: 'Installing dependencies',
-          task: () => installDependencies(projectDir, verbose).catch(e => this.error(`Error during npm install: ${e.message}`, { exit: 13 }))
+          task: () => installDependencies(projectDir, verbose).catch(e => this.error(`Error during npm install: ${e.message}`, { exit: 13 })),
+          enabled: () => !flags.skipInstall
         },
         {
           title: 'Modifying `.gitignore`',

--- a/test/init.spec.ts
+++ b/test/init.spec.ts
@@ -78,7 +78,14 @@ describe('Init', () => {
     const projectDir = getCleanProjectDir('add-to-existing');
     fs.copySync(expressAppDir, projectDir, { recursive: true });
 
-    await Init.run(['--projectName=testingApp', '--startCommand="npm start"', `--projectDir=${projectDir}`, '--no-analytics', '--force']);
+    await Init.run([
+      '--projectName=testingApp',
+      '--startCommand="npm start"',
+      `--projectDir=${projectDir}`,
+      '--no-analytics',
+      '--skipInstall',
+      '--force'
+    ]);
 
     ['.npmrc', 'credentials.json', 'systems.json', 'manifest.yml']
       .map(file => path.resolve(projectDir, file))
@@ -93,7 +100,7 @@ describe('Init', () => {
     fs.copySync(nestAppDir, projectDir, { recursive: true });
     fs.createFileSync(`${projectDir}/.npmrc`);
 
-    await Init.run(['--projectName=testingApp', '--startCommand="npm start"', `--projectDir=${projectDir}`, '--no-analytics']);
+    await Init.run(['--projectName=testingApp', '--startCommand="npm start"', `--projectDir=${projectDir}`, '--skipInstall', '--no-analytics']);
 
     expect(error).toHaveBeenCalledWith(
       'A file with the name ".npmrc" already exists. If you want to overwrite it, rerun the command with `--force`.',
@@ -105,7 +112,7 @@ describe('Init', () => {
     const projectDir = getCleanProjectDir('add-to-gitignore');
     fs.copySync(nestAppDir, projectDir, { recursive: true });
 
-    await Init.run(['--projectName=testingApp', '--startCommand="npm start"', `--projectDir=${projectDir}`, '--no-analytics']);
+    await Init.run(['--projectName=testingApp', '--startCommand="npm start"', `--projectDir=${projectDir}`, '--skipInstall', '--no-analytics']);
 
     const gitignoreEntries = fs
       .readFileSync(`${projectDir}/.gitignore`, 'utf8')
@@ -124,7 +131,7 @@ describe('Init', () => {
     fs.createFileSync(path.resolve(projectDir, 'package.json'));
     fs.writeFileSync(path.resolve(projectDir, 'package.json'), JSON.stringify({ name: 'project' }), 'utf8');
 
-    await Init.run(['--projectName=testingApp', '--startCommand="npm start"', `--projectDir=${projectDir}`, '--no-analytics']);
+    await Init.run(['--projectName=testingApp', '--startCommand="npm start"', `--projectDir=${projectDir}`, '--skipInstall', '--no-analytics']);
 
     expect(warn).toHaveBeenCalledWith('No .gitignore file found!');
   }, 60000);
@@ -134,7 +141,14 @@ describe('Init', () => {
     fs.createFileSync(path.resolve(projectDir, 'package.json'));
     fs.writeFileSync(path.resolve(projectDir, 'package.json'), JSON.stringify({ name: 'project' }), 'utf8');
 
-    await Init.run(['--projectName=testingApp', '--startCommand="npm start"', '--frontendScripts', `--projectDir=${projectDir}`, '--no-analytics']);
+    await Init.run([
+      '--projectName=testingApp',
+      '--startCommand="npm start"',
+      '--frontendScripts',
+      `--projectDir=${projectDir}`,
+      '--skipInstall',
+      '--no-analytics'
+    ]);
 
     const packageJson = JSON.parse(fs.readFileSync(path.resolve(projectDir, 'package.json'), 'utf8'));
 
@@ -157,6 +171,7 @@ describe('Init', () => {
       '--projectName=testingApp',
       '--startCommand="npm start"',
       `--projectDir=${projectDir}`,
+      '--skipInstall',
       '--analytics',
       '--analyticsSalt=SAPCLOUDSDK4LIFE'
     ]);
@@ -168,7 +183,7 @@ describe('Init', () => {
     const projectDir = getCleanProjectDir('add-to-gitignore');
     fs.copySync(expressAppDir, projectDir, { recursive: true });
 
-    await Init.run(['--projectName=testingApp', '--startCommand="npm start"', `--projectDir=${projectDir}`, '--no-analytics']);
+    await Init.run(['--projectName=testingApp', '--startCommand="npm start"', `--projectDir=${projectDir}`, '--skipInstall', '--no-analytics']);
 
     expect(JSON.parse(fs.readFileSync(`${projectDir}/sap-cloud-sdk-analytics.json`, 'utf8'))).toEqual({ enabled: false });
   }, 60000);

--- a/test/init.spec.ts
+++ b/test/init.spec.ts
@@ -93,7 +93,7 @@ describe('Init', () => {
         expect(fs.existsSync(path)).toBe(true);
       });
     expect(fs.existsSync(path.resolve(projectDir, 'test'))).toBe(false);
-  }, 60000);
+  }, 10000);
 
   it('init should detect and fail if there are conflicts', async () => {
     const projectDir = getCleanProjectDir('detect-conflicts');
@@ -106,7 +106,7 @@ describe('Init', () => {
       'A file with the name ".npmrc" already exists. If you want to overwrite it, rerun the command with `--force`.',
       { exit: 1 }
     );
-  }, 60000);
+  }, 10000);
 
   it('should add to .gitignore if there is one', async () => {
     const projectDir = getCleanProjectDir('add-to-gitignore');
@@ -123,7 +123,7 @@ describe('Init', () => {
     expect(gitignoreEntries).toContain('/s4hana_pipeline');
     expect(gitignoreEntries).toContain('/deployment');
     expect(gitignoreEntries.length).toBeGreaterThan(29);
-  }, 60000);
+  }, 10000);
 
   it('should show a warning if the project is not using git', async () => {
     const projectDir = getCleanProjectDir('warn-on-no-git');
@@ -134,7 +134,7 @@ describe('Init', () => {
     await Init.run(['--projectName=testingApp', '--startCommand="npm start"', `--projectDir=${projectDir}`, '--skipInstall', '--no-analytics']);
 
     expect(warn).toHaveBeenCalledWith('No .gitignore file found!');
-  }, 60000);
+  }, 10000);
 
   it('should add our scripts and dependencies to the package.json', async () => {
     const projectDir = getCleanProjectDir('add-scripts-and-dependencies');
@@ -161,7 +161,7 @@ describe('Init', () => {
     ['ci-build', 'ci-package', 'ci-backend-unit-test', 'ci-frontend-unit-test', 'ci-integration-test', 'ci-e2e'].forEach(script =>
       expect(scripts).toContain(script)
     );
-  }, 60000);
+  }, 10000);
 
   it('should add the analytics file', async () => {
     const projectDir = getCleanProjectDir('add-to-gitignore');
@@ -177,7 +177,7 @@ describe('Init', () => {
     ]);
 
     expect(JSON.parse(fs.readFileSync(`${projectDir}/sap-cloud-sdk-analytics.json`, 'utf8'))).toEqual({ enabled: true, salt: 'SAPCLOUDSDK4LIFE' });
-  }, 60000);
+  }, 10000);
 
   it('should add a disabled analytics file', async () => {
     const projectDir = getCleanProjectDir('add-to-gitignore');
@@ -186,5 +186,5 @@ describe('Init', () => {
     await Init.run(['--projectName=testingApp', '--startCommand="npm start"', `--projectDir=${projectDir}`, '--skipInstall', '--no-analytics']);
 
     expect(JSON.parse(fs.readFileSync(`${projectDir}/sap-cloud-sdk-analytics.json`, 'utf8'))).toEqual({ enabled: false });
-  }, 60000);
+  }, 10000);
 });


### PR DESCRIPTION
## Proposed Changes

Artifacts of previously cancelled test runs could pollute the `test/` folder leading to failing tests (as the generated code may contain tests that would be picked up.

Also the tests were very slow. Some of that is difficult to avoid but currently we installed the generated dependencies for each of the init tests which took about 3 min. A new flag allows to skip this and shortens the test cycle by about those 3 min. The first init test still installs dependencies as it verifies that the scaffold is functioning and therefore needs the dependencies to be installed.

## Checklist

- [x] I have added or adjusted tests that prove my fix is effective or that my feature works

## Further Comments

If the changes are complex, please discuss what alternatives you have evaluated and why you picked this particular solution. Please make sure to highlight any trade-offs that we should know about.
