### PR TITLE
Run install with force win32

### DIFF
--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -103,9 +103,10 @@ export default class Package extends Command {
         title: 'Install productive dependencies',
         enabled: () => !flags.skipInstall,
         task: async () =>
-          execa('npm', ['install', '--production', '--prefix', outputDir], { stdio: flags.verbose ? 'inherit' : 'ignore' }).catch(e =>
-            this.error(e, { exit: 10 })
-          )
+          execa('npm', ['install', '--production'], {
+            cwd: path.resolve('outputDir'),
+            stdio: flags.verbose ? 'inherit' : 'ignore'
+          }).catch(e => this.error(e, { exit: 10 }))
       }
     ]);
 

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -105,7 +105,7 @@ export default class Package extends Command {
         enabled: () => !flags.skipInstall,
         task: async () =>
           execa('npm', ['install', '--production', platform() === 'win32' ? '--force' : ''], {
-            cwd: 'outputDir',
+            cwd: path.resolve(projectDir, 'outputDir'),
             stdio: flags.verbose ? 'inherit' : 'ignore'
           }).catch(e => this.error(e, { exit: 10 }))
       }

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -103,10 +103,9 @@ export default class Package extends Command {
         title: 'Install productive dependencies',
         enabled: () => !flags.skipInstall,
         task: async () =>
-          execa('npm', ['install', '--production'], {
-            cwd: path.resolve('outputDir'),
-            stdio: flags.verbose ? 'inherit' : 'ignore'
-          }).catch(e => this.error(e, { exit: 10 }))
+          execa('npm', ['install', '--production', '--prefix', outputDir, '--force'], { stdio: flags.verbose ? 'inherit' : 'ignore' }).catch(e =>
+            this.error(e, { exit: 10 })
+          )
       }
     ]);
 

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -104,8 +104,7 @@ export default class Package extends Command {
         title: 'Install productive dependencies',
         enabled: () => !flags.skipInstall,
         task: async () =>
-          execa('npm', ['install', '--production', platform() === 'win32' ? '--force' : ''], {
-            cwd: path.resolve(projectDir, 'outputDir'),
+          execa('npm', ['install', '--production', `--prefix=${outputDir}`, ...(platform() === 'win32' ? ['--force'] : [])], {
             stdio: flags.verbose ? 'inherit' : 'ignore'
           }).catch(e => this.error(e, { exit: 10 }))
       }

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -7,6 +7,7 @@ import * as execa from 'execa';
 import * as glob from 'fast-glob';
 import * as fs from 'fs';
 import * as Listr from 'listr';
+import { platform } from 'os';
 import * as path from 'path';
 import * as rm from 'rimraf';
 
@@ -103,9 +104,10 @@ export default class Package extends Command {
         title: 'Install productive dependencies',
         enabled: () => !flags.skipInstall,
         task: async () =>
-          execa('npm', ['install', '--production', '--prefix', outputDir, '--force'], { stdio: flags.verbose ? 'inherit' : 'ignore' }).catch(e =>
-            this.error(e, { exit: 10 })
-          )
+          execa('npm', ['install', '--production', platform() === 'win32' ? '--force' : ''], {
+            cwd: 'outputDir',
+            stdio: flags.verbose ? 'inherit' : 'ignore'
+          }).catch(e => this.error(e, { exit: 10 }))
       }
     ]);
 


### PR DESCRIPTION
## Proposed Changes

`sap-cloud-sdk package` was failing on some windows machines. This uses the `--force` flag to fix the issue.

## Further comments

There is an alternative solution: change the `name` property in the `<projectDir>/package.json` before running `npm install` in the `outputDir` and changing it back afterwards. This might create unwanted changes (`JSON.stringify()` creating a different order, command crashing and the restore not working, ...) which can be hard to test for thoroughly. But this alternative avoids the side-effects of `--force` (always loading from the registry instead of using the npm cache, ...).

I decided to use `--force` as it seemed more robust and should only rarely affect users. Package is not a common command for developers (only necessary for a deploy). CI/CD will be running on Linux in most cases and therefore run without `--force`. My assumption is that most deployments are done by CI/CD pipeline and therefore this will have a negligible impact.