### PR TITLE
Fix: Download full file

### DIFF
--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -85,10 +85,11 @@ async function copyRemote(sourcePath: URL, fileName: string) {
         if (response.statusCode && (response.statusCode < 200 || response.statusCode > 299)) {
           reject(new Error('Failed to load page, status code: ' + response.statusCode));
         }
-
-        response.on('data', content => {
+        let data = '';
+        response.on('data', (content:string) => data+=content)
+        response.on('end', () => {
           fs.mkdirSync(path.dirname(fileName), { recursive: true });
-          fs.writeFileSync(fileName, content);
+          fs.writeFileSync(fileName, data);
           resolve();
         });
       })

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -85,11 +85,11 @@ async function copyRemote(sourcePath: URL, fileName: string) {
         if (response.statusCode && (response.statusCode < 200 || response.statusCode > 299)) {
           reject(new Error('Failed to load page, status code: ' + response.statusCode));
         }
-        let data = '';
-        response.on('data', (content:string) => data+=content)
+        let content = '';
+        response.on('data', (chunk:string) => content+=chunk)
         response.on('end', () => {
           fs.mkdirSync(path.dirname(fileName), { recursive: true });
-          fs.writeFileSync(fileName, data);
+          fs.writeFileSync(fileName, content);
           resolve();
         });
       })

--- a/test/add-cx-server.spec.ts
+++ b/test/add-cx-server.spec.ts
@@ -41,10 +41,14 @@ describe('Add CX Server', () => {
 
       const files = fs.readdir(projectDir);
       const approuterFiles = fs.readdir(path.resolve(projectDir, 'cx-server'));
+      const fileContent = fs.readFile(path.resolve(projectDir, 'cx-server','cx-server'),{encoding:'utf8'})
 
-      return Promise.all([files, approuterFiles]).then(values => {
+      return Promise.all([files, approuterFiles, fileContent]).then(values => {
         expect(values[0]).toContain('cx-server');
         expect(values[1]).toIncludeAllMembers(['cx-server', 'cx-server.bat', 'server.cfg']);
+        //Some heuristic test that the content of the script has been downloaded proerly.
+        expect((values[2] as string).startsWith("#!/bin/bash")).toBe(true)
+        expect((values[2] as string).match("docker run"))
       });
     },
     TimeThresholds.SHORT


### PR DESCRIPTION
## Proposed Changes

As @fwilhe supported an issue #104 that the cx-server file is broken. It turns out that the https.get returns the data in chunks and you need to accumulate the `.on(data...` calls until you reach `on.(end...`. This PR considers this and also adds some test for that.

#104

## Checklist

- [X] I have added or adjusted tests that prove my fix is effective or that my feature works
- [X] I have added or adjusted documentation

## Further Comments

If the changes are complex, please discuss what alternatives you have evaluated and why you picked this particular solution. Please make sure to highlight any trade-offs that we should know about.
