### PR TITLE
Excluded deployment folder from tsconfig.build.json

### DIFF
--- a/src/utils/scaffold.ts
+++ b/src/utils/scaffold.ts
@@ -50,6 +50,7 @@ export async function buildScaffold(projectDir: string, verbose: boolean, addCds
 
   fs.unlinkSync(path.resolve(projectDir, 'README.md'));
   modifyMainTs(path.resolve(projectDir, 'src', 'main.ts'));
+  modifyTsconfigBuildJson(path.resolve(projectDir, 'tsconfig.build.json'));
   if (addCds) {
     addCatalogueModule(path.resolve(projectDir, 'src', 'app.module.ts'));
   }
@@ -65,6 +66,18 @@ function modifyMainTs(pathToMainTs: string) {
     recordWarning('Could not set listening port to `process.env.PORT`', 'in file `app.module.ts`. Please adjust manually.');
   } else {
     fs.writeFileSync(pathToMainTs, modifiedMainTs);
+  }
+}
+
+function modifyTsconfigBuildJson(pathToTsconfigBuildJson: string) {
+  const TsconfigBuildJson = fs.readFileSync(pathToTsconfigBuildJson, { encoding: 'utf8' });
+  const modifiedExclude = '  "exclude": ["node_modules", "test", "dist", "deployment", "**/*spec.ts"]';
+  const modifiedTsconfigBuildJson = TsconfigBuildJson.replace('  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]', modifiedExclude);
+
+  if (!modifiedTsconfigBuildJson.includes(modifiedExclude)) {
+    recordWarning('Could not exclude deployment`', 'in file `tsconfig.build.json`. Please adjust manually.');
+  } else {
+    fs.writeFileSync(pathToTsconfigBuildJson, modifiedTsconfigBuildJson);
   }
 }
 

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -86,7 +86,7 @@ async function copyRemote(sourcePath: URL, fileName: string) {
           reject(new Error('Failed to load page, status code: ' + response.statusCode));
         }
         let content = '';
-        response.on('data', (chunk:string) => content+=chunk)
+        response.on('data', (chunk: string) => (content += chunk));
         response.on('end', () => {
           fs.mkdirSync(path.dirname(fileName), { recursive: true });
           fs.writeFileSync(fileName, content);

--- a/test/add-cx-server.spec.ts
+++ b/test/add-cx-server.spec.ts
@@ -41,14 +41,14 @@ describe('Add CX Server', () => {
 
       const files = fs.readdir(projectDir);
       const approuterFiles = fs.readdir(path.resolve(projectDir, 'cx-server'));
-      const fileContent = fs.readFile(path.resolve(projectDir, 'cx-server','cx-server'),{encoding:'utf8'})
+      const fileContent = fs.readFile(path.resolve(projectDir, 'cx-server', 'cx-server'), { encoding: 'utf8' });
 
       return Promise.all([files, approuterFiles, fileContent]).then(values => {
         expect(values[0]).toContain('cx-server');
         expect(values[1]).toIncludeAllMembers(['cx-server', 'cx-server.bat', 'server.cfg']);
-        //Some heuristic test that the content of the script has been downloaded proerly.
-        expect((values[2] as string).startsWith("#!/bin/bash")).toBe(true)
-        expect((values[2] as string).match("docker run"))
+        // Some heuristic test that the content of the script has been downloaded proerly.
+        expect((values[2] as string).startsWith('#!/bin/bash')).toBe(true);
+        expect((values[2] as string).match('docker run'));
       });
     },
     TimeThresholds.SHORT

--- a/test/utils/scaffold.e2e.spec.ts
+++ b/test/utils/scaffold.e2e.spec.ts
@@ -4,6 +4,7 @@
 jest.retryTimes(3);
 
 import * as fs from 'fs-extra';
+import * as path from 'path';
 import { buildScaffold } from '../../src/utils';
 import { deleteAsync, getCleanProjectDir, getTestOutputDir, TimeThresholds } from '../test-utils';
 
@@ -21,8 +22,16 @@ describe('Scaffold Utils', () => {
 
       await buildScaffold(projectDir, false, false);
 
-      const files = await fs.readdir(projectDir);
-      expect(files.sort()).toMatchSnapshot();
+      const files = fs.readdir(projectDir);
+      const mainTs = fs.readFile(path.resolve(projectDir, 'src', 'main.ts'), { encoding: 'utf8' });
+      const tsconfigBuildJson = fs.readFile(path.resolve(projectDir, 'tsconfig.build.json'), { encoding: 'utf8' });
+      const tsconfigJson = fs.readFile(path.resolve(projectDir, 'tsconfig.json'), { encoding: 'utf8' });
+
+      expect((await files).sort()).toMatchSnapshot();
+      expect(await mainTs).toMatch('.listen(process.env.PORT || 3000)');
+      expect(await tsconfigBuildJson).toMatch('deployment');
+      expect(await tsconfigJson).toMatch('"allowJs": true');
+
       return fs.remove(`${testOutputDir}/build-scaffold/src/app.controller.spec.ts`);
     },
     TimeThresholds.LONG


### PR DESCRIPTION
## Proposed Changes

If you add "allowJs": true in your tsconfig.json file which looks for all js files, even the ones in the deployment folder and puts them again in the dist folder.
Solution: added the deployment folder to the exclude list in tsconfig.build.json
https://github.com/SAP/cloud-sdk-cli/issues/103
https://github.wdf.sap.corp/MA/scp-rocket/issues/1368

## Checklist

- [x] I have added or adjusted tests that prove my fix is effective or that my feature works
- [ ] I have added or adjusted documentation
