### PR TITLE
chore: move e2e tests to nightly job

### DIFF
--- a/.github/workflows/nightly-e2e-tests.yml
+++ b/.github/workflows/nightly-e2e-tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
         node-version: [10.x, 12.x]
 
     steps:

--- a/.github/workflows/nightly-e2e-tests.yml
+++ b/.github/workflows/nightly-e2e-tests.yml
@@ -1,0 +1,39 @@
+name: nightly-e2e-tests
+
+on:
+  schedule:
+    - cron:  '* 12 * * *'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+        node-version: [10.x, 12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get yarn cache directory
+        id: yarn-cache
+        if: runner.os == 'Linux'
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Save/restore yarn cache
+        uses: actions/cache@v1
+        if: runner.os == 'Linux'
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile --ignore-engines
+      - run: yarn build
+      - run: yarn run test:e2e
+        env:
+          CI: true

--- a/.github/workflows/nightly-e2e-tests.yml
+++ b/.github/workflows/nightly-e2e-tests.yml
@@ -2,7 +2,7 @@ name: nightly-e2e-tests
 
 on:
   schedule:
-    - cron:  '* 12 * * *'
+    - cron:  '* 23 * * *'
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
       - run: yarn build
       - run: yarn run test
       - run: yarn run test:e2e
+        if: matrix.os == 'ubuntu-latest'
         env:
           CI: true
   checks:


### PR DESCRIPTION
## Proposed Changes

- the e2e tests will still be triggered by every commit, but only with ubuntu os.
- the e2e tests on windows and Mac-os are moved to the nightly job
- the main build will still cost ~ 5 min, which might not good when moving to sdk repo, but is faster than 10+ min (current).

<!-- Link with "Closes #ISSUE-NUMBER" -->

## Checklist

- [ ] I have added or adjusted tests that prove my fix is effective or that my feature works
- [ ] I have added or adjusted documentation

## Further Comments

If the changes are complex, please discuss what alternatives you have evaluated and why you picked this particular solution. Please make sure to highlight any trade-offs that we should know about.
